### PR TITLE
Improve command short and long description

### DIFF
--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Manipulates the WP Object Cache. 
+ * Manipulates the WP Object Cache
  *
  *
  * Use a persistent object cache drop-in to persist cache values between requests.

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -1,12 +1,11 @@
 <?php
 
 /**
- * cache manipulates the WP Object Cache. 
+ * Manipulates the WP Object Cache. 
  *
  *
- * Use a persistent object cache drop-in to persist cache values between requests. 
- *
- * See the Codex for [WP Object Cache](https://codex.wordpress.org/Class_Reference/WP_Object_Cache).
+ * Use a persistent object cache drop-in to persist cache values between requests.
+ * [WP Object Cache](https://codex.wordpress.org/Class_Reference/WP_Object_Cache)
  *
  * ## EXAMPLES
  *

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -2,7 +2,7 @@
 
 /**
  * The cache command manipulates the WP Object Cache. Codex: https://codex.wordpress.org/Class_Reference/WP_Object_Cache.
- * This is a a test
+ *
  *
  * Use a persistent object cache drop-in to persist cache values between requests.
  *

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -1,7 +1,11 @@
 <?php
 
 /**
- * Manage the object cache.
+ * The cache command manipulates the WP Object Cache, an object containing data which may be 
+ * computationally expensive to regenerate, like the results of complex database queries. For more 
+ * information on the WP Object Cache see:  
+ * https://codex.wordpress.org/Class_Reference/WP_Object_Cache
+ * 
  *
  * Use a persistent object cache drop-in to persist cache values between requests.
  *

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -1,10 +1,12 @@
 <?php
 
 /**
- * The cache command manipulates the WP Object Cache. Codex: https://codex.wordpress.org/Class_Reference/WP_Object_Cache.
+ * cache manipulates the WP Object Cache. 
  *
  *
- * Use a persistent object cache drop-in to persist cache values between requests.
+ * Use a persistent object cache drop-in to persist cache values between requests. 
+ *
+ * See the Codex for [WP Object Cache](https://codex.wordpress.org/Class_Reference/WP_Object_Cache).
  *
  * ## EXAMPLES
  *

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -1,11 +1,8 @@
 <?php
 
 /**
- * The cache command manipulates the WP Object Cache, an object containing data which may be 
- * computationally expensive to regenerate, like the results of complex database queries. For more 
- * information on the WP Object Cache see:  
- * https://codex.wordpress.org/Class_Reference/WP_Object_Cache
- * 
+ * The cache command manipulates the WP Object Cache. Codex: https://codex.wordpress.org/Class_Reference/WP_Object_Cache.
+ * This is a a test
  *
  * Use a persistent object cache drop-in to persist cache values between requests.
  *

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Manipulates the WP Object Cache
+ * Manipulates the WP Object Cache.
  *
  *
  * Use a persistent object cache drop-in to persist cache values between requests.


### PR DESCRIPTION
Improve command short and long description in
https://github.com/wp-cli/cache-command/src/Cache_Command.php

wp cache | Manage the object cache.

Proposed short description:
Manipulates the WP Object Cache.

Proposed long description:
Use a persistent object cache drop-in to persist cache values between requests.
WP Object Cache

cc:@hearvox
