### PR TITLE
Convert cache and transient help summaries to use third-person singular verbs.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,6 @@
 # Used by Probot Settings: https://probot.github.io/apps/settings/
 repository:
-  description: Manage object and transient caches.
+  description: Manages object and transient caches.
 labels:
   - name: bug
     color: fc2929

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package implements the following commands:
 
 ### wp cache
 
-Manipulate the WP Object Cache object.
+Adds, removes, fetches, and flushes the WP Object Cache object.
 
 ~~~
 wp cache
@@ -40,7 +40,7 @@ for more detail.
 
 ### wp cache add
 
-Add a value to the object cache.
+Adds a value to the object cache.
 
 ~~~
 wp cache add <key> <value> [<group>] [<expiration>]
@@ -79,7 +79,7 @@ be added.
 
 ### wp cache decr
 
-Decrement a value in the object cache.
+Decrements a value in the object cache.
 
 ~~~
 wp cache decr <key> [<offset>] [<group>]
@@ -114,7 +114,7 @@ Errors if the value can't be decremented.
 
 ### wp cache delete
 
-Remove a value from the object cache.
+Removes a value from the object cache.
 
 ~~~
 wp cache delete <key> [<group>]
@@ -143,7 +143,7 @@ Errors if the value can't be deleted.
 
 ### wp cache flush
 
-Flush the object cache.
+Flushes the object cache.
 
 ~~~
 wp cache flush 
@@ -166,7 +166,7 @@ Errors if the object cache can't be flushed.
 
 ### wp cache get
 
-Get a value from the object cache.
+Gets a value from the object cache.
 
 ~~~
 wp cache get <key> [<group>]
@@ -195,7 +195,7 @@ Errors if the value doesn't exist.
 
 ### wp cache incr
 
-Increment a value in the object cache.
+Increments a value in the object cache.
 
 ~~~
 wp cache incr <key> [<offset>] [<group>]
@@ -230,7 +230,7 @@ Errors if the value can't be incremented.
 
 ### wp cache replace
 
-Replace a value in the object cache, if the value already exists.
+Replaces a value in the object cache, if the value already exists.
 
 ~~~
 wp cache replace <key> <value> [<group>] [<expiration>]
@@ -268,7 +268,7 @@ Errors if the value can't be replaced.
 
 ### wp cache set
 
-Set a value to the object cache, regardless of whether it already exists.
+Sets a value to the object cache, regardless of whether it already exists.
 
 ~~~
 wp cache set <key> <value> [<group>] [<expiration>]
@@ -327,7 +327,7 @@ ability to determine which object cache is being used.
 
 ### wp transient
 
-Manipulate the WordPress Transient Cache.
+Adds, gets, and deletes entries in the WordPress Transient Cache.
 
 ~~~
 wp transient
@@ -363,7 +363,7 @@ transient cache also uses the WordPress Object Cache.
 
 ### wp transient delete
 
-Delete a transient value.
+Deletes a transient value.
 
 ~~~
 wp transient delete [<key>] [--network] [--all] [--expired]
@@ -401,7 +401,7 @@ wp transient delete [<key>] [--network] [--all] [--expired]
 
 ### wp transient get
 
-Get a transient value.
+Gets a transient value.
 
 ~~~
 wp transient get <key> [--format=<format>] [--network]
@@ -438,7 +438,7 @@ wp transient get <key> [--format=<format>] [--network]
 
 ### wp transient set
 
-Set a transient value.
+Sets a transient value.
 
 ~~~
 wp transient set <key> <value> [<expiration>] [--network]
@@ -469,7 +469,7 @@ wp transient set <key> <value> [<expiration>] [--network]
 
 ### wp transient type
 
-Determine type of transients implementation.
+Determines the type of transients implementation.
 
 ~~~
 wp transient type 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-cli/cache-command",
-    "description": "Manage object and transient caches.",
+    "description": "Manages object and transient caches.",
     "type": "wp-cli-package",
     "homepage": "https://github.com/wp-cli/cache-command",
     "support": {

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Manipulate the WP Object Cache object.
+ * Manipulates the WP Object Cache object.
  *
  * By default, the WP Object Cache exists in PHP memory for the length of the
  * request (and is emptied at the end). Use a persistent object cache drop-in
@@ -25,7 +25,7 @@
 class Cache_Command extends WP_CLI_Command {
 
 	/**
-	 * Add a value to the object cache.
+	 * Adds a value to the object cache.
 	 *
 	 * Errors if a value already exists for the key, which means the value can't
 	 * be added.
@@ -67,7 +67,7 @@ class Cache_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Decrement a value in the object cache.
+	 * Decrements a value in the object cache.
 	 *
 	 * Errors if the value can't be decremented.
 	 *
@@ -106,7 +106,7 @@ class Cache_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Remove a value from the object cache.
+	 * Removes a value from the object cache.
 	 *
 	 * Errors if the value can't be deleted.
 	 *
@@ -139,7 +139,7 @@ class Cache_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Flush the object cache.
+	 * Flushes the object cache.
 	 *
 	 * For WordPress multisite instances using a persistent object cache,
 	 * flushing the object cache will typically flush the cache for all sites.
@@ -165,7 +165,7 @@ class Cache_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get a value from the object cache.
+	 * Gets a value from the object cache.
 	 *
 	 * Errors if the value doesn't exist.
 	 *
@@ -198,7 +198,7 @@ class Cache_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Increment a value in the object cache.
+	 * Increments a value in the object cache.
 	 *
 	 * Errors if the value can't be incremented.
 	 *
@@ -237,7 +237,7 @@ class Cache_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Replace a value in the object cache, if the value already exists.
+	 * Replaces a value in the object cache, if the value already exists.
 	 *
 	 * Errors if the value can't be replaced.
 	 *
@@ -279,7 +279,7 @@ class Cache_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Set a value to the object cache, regardless of whether it already exists.
+	 * Sets a value to the object cache, regardless of whether it already exists.
 	 *
 	 * Errors if the value can't be set.
 	 *

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Manipulates the WP Object Cache object.
+ * Adds, removes, fetches, and flushes the WP Object Cache object.
  *
  * By default, the WP Object Cache exists in PHP memory for the length of the
  * request (and is emptied at the end). Use a persistent object cache drop-in

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Manipulate the WordPress Transient Cache.
+ * Manipulates the WordPress Transient Cache.
  *
  * By default, the transient cache uses the WordPress database to persist values
  * between requests. When a persistent object cache drop-in is installed, the
@@ -32,7 +32,7 @@
 class Transient_Command extends WP_CLI_Command {
 
 	/**
-	 * Get a transient value.
+	 * Gets a transient value.
 	 *
 	 * ## OPTIONS
 	 *
@@ -76,7 +76,7 @@ class Transient_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Set a transient value.
+	 * Sets a transient value.
 	 *
 	 * `<expiration>` is the time until expiration, in seconds.
 	 *
@@ -113,7 +113,7 @@ class Transient_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Delete a transient value.
+	 * Deletes a transient value.
 	 *
 	 * ## OPTIONS
 	 *
@@ -176,7 +176,7 @@ class Transient_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Determine type of transients implementation.
+	 * Determines the type of transients implementation.
 	 *
 	 * Indicates whether the transients API is using an object cache or the
 	 * options table.
@@ -198,7 +198,7 @@ class Transient_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Delete all expired transients.
+	 * Deletes all expired transients.
 	 */
 	private function delete_expired() {
 		global $wpdb, $_wp_using_ext_object_cache;
@@ -225,7 +225,7 @@ class Transient_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Delete all transients.
+	 * Deletes all transients.
 	 */
 	private function delete_all() {
 		global $wpdb, $_wp_using_ext_object_cache;

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Manipulates the WordPress Transient Cache.
+ * Adds, gets, and deletes entries in the WordPress Transient Cache.
  *
  * By default, the transient cache uses the WordPress database to persist values
  * between requests. When a persistent object cache drop-in is installed, the


### PR DESCRIPTION
Per wp-cli/wp-cli#4542, this PR converts help docs for commands and subcommands to use third-person singular verbs for the `cache` and `transient` commands, respectively.