### PR TITLE
Improve deleting site transients

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,9 +403,20 @@ network|site cache, please see docs for `wp transient`.
     $ wp transient delete --expired
     Success: 12 expired transients deleted from the database.
 
+    # Delete expired site transients.
+    $ wp transient delete --expired --network
+    Success: 1 expired transient deleted from the database.
+
     # Delete all transients.
     $ wp transient delete --all
     Success: 14 transients deleted from the database.
+
+    # Delete all site transients.
+    $ wp transient delete --all --network
+    Success: 2 transients deleted from the database.
+
+    # Delete all transients in a multsite.
+    $ wp transient delete --all --network && wp site list --field=url | xargs -n1 -I % wp --url=% transient delete --all
 
 
 
@@ -496,7 +507,7 @@ wp transient type
 ~~~
 
 Indicates whether the transients API is using an object cache or the
-options table.
+database.
 
 For a more complete explanation of the transient cache, including the
 network|site cache, please see docs for `wp transient`.
@@ -504,7 +515,7 @@ network|site cache, please see docs for `wp transient`.
 **EXAMPLES**
 
     $ wp transient type
-    Transients are saved to the wp_options table.
+    Transients are saved to the database.
 
 ## Installing
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "wp-cli/entity-command": "^1.3 || ^2",
-        "wp-cli/wp-cli-tests": "^2.0.7"
+        "wp-cli/wp-cli-tests": "^2.0.11"
     },
     "config": {
         "process-timeout": 7200,

--- a/features/transient.feature
+++ b/features/transient.feature
@@ -55,10 +55,9 @@ Feature: Manage WordPress transient cache
       Success: Transient deleted.
       """
 
-    When I run `wp transient delete --all`
-    And I run `wp transient set foo bar --network`
+    When I run `wp transient set foo bar --network`
     And I run `wp transient set foo2 bar2 --network`
-    And I run `wp transient delete --all`
+    And I run `wp transient delete --all --network`
     Then STDOUT should be:
       """
       Success: 2 transients deleted from the database.
@@ -73,14 +72,19 @@ Feature: Manage WordPress transient cache
       Error: Please specify transient key, or use --all or --expired.
       """
 
-    When I run `wp transient delete --all`
-    And I run `wp transient set foo bar`
+    When I run `wp transient set foo bar`
     And I run `wp transient set foo2 bar2`
     And I run `wp transient set foo3 bar3 --network`
     And I run `wp transient delete --all`
     Then STDOUT should be:
       """
-      Success: 3 transients deleted from the database.
+      Success: 2 transients deleted from the database.
+      """
+
+    When I run `wp transient delete --all --network`
+    Then STDOUT should be:
+      """
+      Success: 1 transient deleted from the database.
       """
 
     When I try `wp transient get foo`
@@ -129,7 +133,7 @@ Feature: Manage WordPress transient cache
 
     # Change timeout to be in the past.
     When I run `wp option update _site_transient_timeout_foo 1321009871`
-    And I run `wp transient delete --expired`
+    And I run `wp transient delete --expired --network`
     Then STDOUT should be:
       """
       Success: 1 expired transient deleted from the database.
@@ -141,28 +145,38 @@ Feature: Manage WordPress transient cache
       Warning: Transient with key "foo" is not set.
       """
 
-    When I run `wp transient delete --all`
-    And I run `wp transient set foo bar`
+    When I run `wp transient set foo bar`
     And I run `wp transient set foo2 bar2 600`
     And I run `wp transient set foo3 bar3 --network`
     And I run `wp transient set foo4 bar4 600 --network`
     And I run `wp transient delete --all`
     Then STDOUT should be:
       """
-      Success: 4 transients deleted from the database.
+      Success: 2 transients deleted from the database.
+      """
+
+    When I run `wp transient delete --all --network`
+    Then STDOUT should be:
+      """
+      Success: 2 transients deleted from the database.
       """
 
   Scenario: Network transient delete and other flags
     Given a WP multisite install
 
-    When I run `wp transient delete --all`
-    And I run `wp transient set foo bar`
+    When I run `wp transient set foo bar`
     And I run `wp transient set foo2 bar2`
     And I run `wp transient set foo3 bar3 --network`
     And I run `wp transient delete --all`
     Then STDOUT should be:
       """
-      Success: 3 transients deleted from the database.
+      Success: 2 transients deleted from the database.
+      """
+
+    When I run `wp transient delete --all --network`
+    Then STDOUT should be:
+      """
+      Success: 1 transient deleted from the database.
       """
 
     When I try `wp transient get foo`
@@ -211,7 +225,7 @@ Feature: Manage WordPress transient cache
 
     # Change timeout to be in the past.
     When I run `wp site option update _site_transient_timeout_foo 1321009871`
-    And I run `wp transient delete --expired`
+    And I run `wp transient delete --expired --network`
     Then STDOUT should be:
       """
       Success: 1 expired transient deleted from the database.
@@ -223,13 +237,18 @@ Feature: Manage WordPress transient cache
       Warning: Transient with key "foo" is not set.
       """
 
-    When I run `wp transient delete --all`
-    And I run `wp transient set foo bar`
+    When I run `wp transient set foo bar`
     And I run `wp transient set foo2 bar2 600`
     And I run `wp transient set foo3 bar3 --network`
     And I run `wp transient set foo4 bar4 600 --network`
     And I run `wp transient delete --all`
     Then STDOUT should be:
       """
-      Success: 4 transients deleted from the database.
+      Success: 2 transients deleted from the database.
+      """
+
+    When  I run `wp transient delete --all --network`
+    Then STDOUT should be:
+      """
+      Success: 2 transients deleted from the database.
       """

--- a/features/transient.feature
+++ b/features/transient.feature
@@ -286,8 +286,8 @@ Feature: Manage WordPress transient cache
     And I run `wp --url=example.com/foo transient set foo6 bar6 60 --network`
     # Change timeout to be in the past.
     And I run `wp option update _transient_timeout_foo 1321009871`
-    And I run `wp option update _site_transient_timeout_foo3 1321009871`
-    And I run `wp --url=example.com/foo option update _site_transient_timeout_foo5 1321009871`
+    And I run `wp site option update _site_transient_timeout_foo3 1321009871`
+    And I run `wp --url=example.com/foo site option update _site_transient_timeout_foo5 1321009871`
     And I run `wp transient delete --expired`
     Then STDOUT should be:
       """

--- a/features/transient.feature
+++ b/features/transient.feature
@@ -141,6 +141,17 @@ Feature: Manage WordPress transient cache
       Warning: Transient with key "foo" is not set.
       """
 
+    When I run `wp transient delete --all`
+    And I run `wp transient set foo bar`
+    And I run `wp transient set foo2 bar2 600`
+    And I run `wp transient set foo3 bar3 --network`
+    And I run `wp transient set foo4 bar4 600 --network`
+    And I run `wp transient delete --all`
+    Then STDOUT should be:
+      """
+      Success: 4 transients deleted from the database.
+      """
+
   Scenario: Network transient delete and other flags
     Given a WP multisite install
 
@@ -210,4 +221,15 @@ Feature: Manage WordPress transient cache
     Then STDERR should be:
       """
       Warning: Transient with key "foo" is not set.
+      """
+
+    When I run `wp transient delete --all`
+    And I run `wp transient set foo bar`
+    And I run `wp transient set foo2 bar2 600`
+    And I run `wp transient set foo3 bar3 --network`
+    And I run `wp transient set foo4 bar4 600 --network`
+    And I run `wp transient delete --all`
+    Then STDOUT should be:
+      """
+      Success: 4 transients deleted from the database.
       """

--- a/features/transient.feature
+++ b/features/transient.feature
@@ -55,15 +55,7 @@ Feature: Manage WordPress transient cache
       Success: Transient deleted.
       """
 
-    When I run `wp transient set foo bar --network`
-    And I run `wp transient set foo2 bar2 --network`
-    And I run `wp transient delete --all --network`
-    Then STDOUT should be:
-      """
-      Success: 2 transients deleted from the database.
-      """
-
-  Scenario: Transient delete and other flags
+  Scenario: Deleting all transients on single site
     Given a WP install
 
     When I try `wp transient delete`
@@ -73,18 +65,13 @@ Feature: Manage WordPress transient cache
       """
 
     When I run `wp transient set foo bar`
-    And I run `wp transient set foo2 bar2`
+    And I run `wp transient set foo2 bar2 600`
     And I run `wp transient set foo3 bar3 --network`
+    And I run `wp transient set foo4 bar4 600 --network`
     And I run `wp transient delete --all`
     Then STDOUT should be:
       """
       Success: 2 transients deleted from the database.
-      """
-
-    When I run `wp transient delete --all --network`
-    Then STDOUT should be:
-      """
-      Success: 1 transient deleted from the database.
       """
 
     When I try `wp transient get foo`
@@ -99,20 +86,46 @@ Feature: Manage WordPress transient cache
       Warning: Transient with key "foo2" is not set.
       """
 
+    When I run `wp transient get foo3 --network`
+    Then STDOUT should be:
+      """
+      bar3
+      """
+
+    When I run `wp transient get foo4 --network`
+    Then STDOUT should be:
+      """
+      bar4
+      """
+
+    When I run `wp transient delete --all --network`
+    Then STDOUT should be:
+      """
+      Success: 2 transients deleted from the database.
+      """
+
     When I try `wp transient get foo3 --network`
     Then STDERR should be:
       """
       Warning: Transient with key "foo3" is not set.
       """
 
-    When I run `wp transient set foo bar 60`
-    Then STDOUT should be:
+    When I try `wp transient get foo4 --network`
+    Then STDERR should be:
       """
-      Success: Transient added.
+      Warning: Transient with key "foo4" is not set.
       """
 
+  Scenario: Deleting expired transients on single site
+    Given a WP install
+
+    When I run `wp transient set foo bar 60`
+    And I run `wp transient set foo2 bar2 60`
+    And I run `wp transient set foo3 bar3 60 --network`
+    And I run `wp transient set foo4 bar4 60 --network`
     # Change timeout to be in the past.
-    When I run `wp option update _transient_timeout_foo 1321009871`
+    And I run `wp option update _transient_timeout_foo 1321009871`
+    And I run `wp option update _site_transient_timeout_foo3 1321009871`
     And I run `wp transient delete --expired`
     Then STDOUT should be:
       """
@@ -125,58 +138,74 @@ Feature: Manage WordPress transient cache
       Warning: Transient with key "foo" is not set.
       """
 
-    When I run `wp transient set foo bar 60 --network`
+    When I run `wp transient get foo2`
     Then STDOUT should be:
       """
-      Success: Transient added.
+      bar2
       """
 
-    # Change timeout to be in the past.
-    When I run `wp option update _site_transient_timeout_foo 1321009871`
-    And I run `wp transient delete --expired --network`
+    When I run `wp transient get foo3 --network`
     Then STDOUT should be:
       """
-      Success: 1 expired transient deleted from the database.
+      bar3
       """
 
-    When I try `wp transient get foo --network`
+    When I run `wp transient get foo4 --network`
+    Then STDOUT should be:
+      """
+      bar4
+      """
+
+    When I run `wp transient delete --expired --network`
+    Then STDOUT should be:
+      """
+      Success: 1 expired transients deleted from the database.
+      """
+
+    When I try `wp transient get foo`
     Then STDERR should be:
       """
       Warning: Transient with key "foo" is not set.
       """
 
-    When I run `wp transient set foo bar`
-    And I run `wp transient set foo2 bar2 600`
-    And I run `wp transient set foo3 bar3 --network`
-    And I run `wp transient set foo4 bar4 600 --network`
-    And I run `wp transient delete --all`
+    When I run `wp transient get foo2`
     Then STDOUT should be:
       """
-      Success: 2 transients deleted from the database.
+      bar2
       """
 
-    When I run `wp transient delete --all --network`
+    When I try `wp transient get foo3 --network`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo3" is not set.
+      """
+
+    When I run `wp transient get foo4 --network`
     Then STDOUT should be:
       """
-      Success: 2 transients deleted from the database.
+      bar4
       """
 
-  Scenario: Network transient delete and other flags
+  Scenario: Deleting all transients on multisite
     Given a WP multisite install
+    And I run `wp site create --slug=foo`
+
+    When I try `wp transient delete`
+    Then STDERR should be:
+      """
+      Error: Please specify transient key, or use --all or --expired.
+      """
 
     When I run `wp transient set foo bar`
-    And I run `wp transient set foo2 bar2`
+    And I run `wp transient set foo2 bar2 600`
     And I run `wp transient set foo3 bar3 --network`
+    And I run `wp transient set foo4 bar4 600 --network`
+    And I run `wp --url=example.com/foo transient set foo5 bar5 --network`
+    And I run `wp --url=example.com/foo transient set foo6 bar6 600 --network`
     And I run `wp transient delete --all`
     Then STDOUT should be:
       """
       Success: 2 transients deleted from the database.
-      """
-
-    When I run `wp transient delete --all --network`
-    Then STDOUT should be:
-      """
-      Success: 1 transient deleted from the database.
       """
 
     When I try `wp transient get foo`
@@ -191,20 +220,74 @@ Feature: Manage WordPress transient cache
       Warning: Transient with key "foo2" is not set.
       """
 
+    When I run `wp transient get foo3 --network`
+    Then STDOUT should be:
+      """
+      bar3
+      """
+
+    When I run `wp transient get foo4 --network`
+    Then STDOUT should be:
+      """
+      bar4
+      """
+
+    When I run `wp --url=example.com/foo transient get foo5 --network`
+    Then STDOUT should be:
+      """
+      bar5
+      """
+
+    When I run `wp --url=example.com/foo transient get foo6 --network`
+    Then STDOUT should be:
+      """
+      bar6
+      """
+
+    When I run `wp transient delete --all --network`
+    Then STDOUT should be:
+      """
+      Success: 4 transients deleted from the database.
+      """
+
     When I try `wp transient get foo3 --network`
     Then STDERR should be:
       """
       Warning: Transient with key "foo3" is not set.
       """
 
-    When I run `wp transient set foo bar 60`
-    Then STDOUT should be:
+    When I try `wp transient get foo4 --network`
+    Then STDERR should be:
       """
-      Success: Transient added.
+      Warning: Transient with key "foo4" is not set.
       """
 
+    When I try `wp --url=example.com/foo transient get foo5 --network`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo5" is not set.
+      """
+
+    When I try `wp --url=example.com/foo transient get foo6 --network`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo6" is not set.
+      """
+
+  Scenario: Deleting expired transients on multisite
+    Given a WP multisite install
+    And I run `wp site create --slug=foo`
+
+    When I run `wp transient set foo bar 60`
+    And I run `wp transient set foo2 bar2 60`
+    And I run `wp transient set foo3 bar3 60 --network`
+    And I run `wp transient set foo4 bar4 60 --network`
+    And I run `wp --url=example.com/foo transient set foo5 bar5 60 --network`
+    And I run `wp --url=example.com/foo transient set foo6 bar6 60 --network`
     # Change timeout to be in the past.
-    When I run `wp option update _transient_timeout_foo 1321009871`
+    And I run `wp option update _transient_timeout_foo 1321009871`
+    And I run `wp option update _site_transient_timeout_foo3 1321009871`
+    And I run `wp --url=example.com/foo option update _site_transient_timeout_foo5 1321009871`
     And I run `wp transient delete --expired`
     Then STDOUT should be:
       """
@@ -217,38 +300,74 @@ Feature: Manage WordPress transient cache
       Warning: Transient with key "foo" is not set.
       """
 
-    When I run `wp transient set foo bar 60 --network`
+    When I run `wp transient get foo2`
     Then STDOUT should be:
       """
-      Success: Transient added.
+      bar2
       """
 
-    # Change timeout to be in the past.
-    When I run `wp site option update _site_transient_timeout_foo 1321009871`
-    And I run `wp transient delete --expired --network`
+    When I run `wp transient get foo3 --network`
     Then STDOUT should be:
       """
-      Success: 1 expired transient deleted from the database.
+      bar3
       """
 
-    When I try `wp transient get foo --network`
+    When I run `wp transient get foo4 --network`
+    Then STDOUT should be:
+      """
+      bar4
+      """
+
+    When I run `wp --url=example.com/foo transient get foo5 --network`
+    Then STDOUT should be:
+      """
+      bar5
+      """
+
+    When I run `wp --url=example.com/foo transient get foo6 --network`
+    Then STDOUT should be:
+      """
+      bar6
+      """
+
+    When I run `wp transient delete --expired --network`
+    Then STDOUT should be:
+      """
+      Success: 2 expired transients deleted from the database.
+      """
+
+    When I try `wp transient get foo`
     Then STDERR should be:
       """
       Warning: Transient with key "foo" is not set.
       """
 
-    When I run `wp transient set foo bar`
-    And I run `wp transient set foo2 bar2 600`
-    And I run `wp transient set foo3 bar3 --network`
-    And I run `wp transient set foo4 bar4 600 --network`
-    And I run `wp transient delete --all`
+    When I run `wp transient get foo2`
     Then STDOUT should be:
       """
-      Success: 2 transients deleted from the database.
+      bar2
       """
 
-    When  I run `wp transient delete --all --network`
+    When I try `wp transient get foo3 --network`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo3" is not set.
+      """
+
+    When I run `wp transient get foo4 --network`
     Then STDOUT should be:
       """
-      Success: 2 transients deleted from the database.
+      bar4
+      """
+
+    When I try `wp --url=example.com/foo transient get foo5 --network`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo5" is not set.
+      """
+
+    When I run `wp --url=example.com/foo transient get foo6 --network`
+    Then STDOUT should be:
+      """
+      bar6
       """

--- a/features/transient.feature
+++ b/features/transient.feature
@@ -118,15 +118,15 @@ Feature: Manage WordPress transient cache
 
   Scenario: Deleting expired transients on single site
     Given a WP install
-
-    When I run `wp transient set foo bar 60`
+    And I run `wp transient set foo bar 60`
     And I run `wp transient set foo2 bar2 60`
     And I run `wp transient set foo3 bar3 60 --network`
     And I run `wp transient set foo4 bar4 60 --network`
     # Change timeout to be in the past.
     And I run `wp option update _transient_timeout_foo 1321009871`
     And I run `wp option update _site_transient_timeout_foo3 1321009871`
-    And I run `wp transient delete --expired`
+
+    When I run `wp transient delete --expired`
     Then STDOUT should be:
       """
       Success: 1 expired transient deleted from the database.
@@ -278,8 +278,7 @@ Feature: Manage WordPress transient cache
   Scenario: Deleting expired transients on multisite
     Given a WP multisite install
     And I run `wp site create --slug=foo`
-
-    When I run `wp transient set foo bar 60`
+    And I run `wp transient set foo bar 60`
     And I run `wp transient set foo2 bar2 60`
     And I run `wp transient set foo3 bar3 60 --network`
     And I run `wp transient set foo4 bar4 60 --network`
@@ -289,7 +288,8 @@ Feature: Manage WordPress transient cache
     And I run `wp option update _transient_timeout_foo 1321009871`
     And I run `wp site option update _site_transient_timeout_foo3 1321009871`
     And I run `wp --url=example.com/foo site option update _site_transient_timeout_foo5 1321009871`
-    And I run `wp transient delete --expired`
+
+    When I run `wp transient delete --expired`
     Then STDOUT should be:
       """
       Success: 1 expired transient deleted from the database.

--- a/features/transient.feature
+++ b/features/transient.feature
@@ -144,7 +144,8 @@ Feature: Manage WordPress transient cache
       bar2
       """
 
-    When I run `wp transient get foo3 --network`
+    # Check if option still exists as a get transient call will remove it.
+    When I run `wp option get _site_transient_foo3`
     Then STDOUT should be:
       """
       bar3
@@ -159,7 +160,7 @@ Feature: Manage WordPress transient cache
     When I run `wp transient delete --expired --network`
     Then STDOUT should be:
       """
-      Success: 1 expired transients deleted from the database.
+      Success: 1 expired transient deleted from the database.
       """
 
     When I try `wp transient get foo`
@@ -306,7 +307,8 @@ Feature: Manage WordPress transient cache
       bar2
       """
 
-    When I run `wp transient get foo3 --network`
+    # Check if option still exists as a get transient call will remove it.
+    When I run `wp site option get _site_transient_foo3`
     Then STDOUT should be:
       """
       bar3
@@ -318,7 +320,8 @@ Feature: Manage WordPress transient cache
       bar4
       """
 
-    When I run `wp --url=example.com/foo transient get foo5 --network`
+    # Check if option still exists as a get transient call will remove it.
+    When I run `wp --url=example.com/foo site option get _site_transient_foo5`
     Then STDOUT should be:
       """
       bar5

--- a/features/transient.feature
+++ b/features/transient.feature
@@ -55,6 +55,14 @@ Feature: Manage WordPress transient cache
       Success: Transient deleted.
       """
 
+    When I run `wp transient set foo bar --network`
+    And I run `wp transient set foo2 bar2 --network`
+    And I run `wp transient delete --all`
+    Then STDOUT should contain:
+      """
+      transients deleted from the database.
+      """
+
   Scenario: Transient delete and other flags
     Given a WP install
 
@@ -66,6 +74,7 @@ Feature: Manage WordPress transient cache
 
     When I run `wp transient set foo bar`
     And I run `wp transient set foo2 bar2`
+    And I run `wp transient set foo3 bar3 --network`
     And I run `wp transient delete --all`
     Then STDOUT should contain:
       """
@@ -82,4 +91,120 @@ Feature: Manage WordPress transient cache
     Then STDERR should be:
       """
       Warning: Transient with key "foo2" is not set.
+      """
+
+    When I try `wp transient get foo3 --network`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo3" is not set.
+      """
+
+    When I run `wp transient set foo bar 60`
+    Then STDOUT should be:
+      """
+      Success: Transient added.
+      """
+
+    # Change timeout to be in the past.
+    When I run `wp option update _transient_timeout_foo 1321009871`
+    And I run `wp transient delete --expired`
+    Then STDOUT should contain:
+      """
+      transient deleted from the database.
+      """
+
+    When I try `wp transient get foo`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo" is not set.
+      """
+
+    When I run `wp transient set foo bar 60 --network`
+    Then STDOUT should be:
+      """
+      Success: Transient added.
+      """
+
+    # Change timeout to be in the past.
+    When I run `wp option update _site_transient_timeout_foo 1321009871`
+    And I run `wp transient delete --expired`
+    Then STDOUT should contain:
+      """
+      transient deleted from the database.
+      """
+
+    When I try `wp transient get foo --network`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo" is not set.
+      """
+
+  Scenario: Network transient delete and other flags
+    Given a WP multisite install
+
+    When I run `wp transient set foo bar`
+    And I run `wp transient set foo2 bar2`
+    And I run `wp transient set foo3 bar3 --network`
+    And I run `wp transient delete --all`
+    Then STDOUT should contain:
+      """
+      transients deleted from the database.
+      """
+
+    When I try `wp transient get foo`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo" is not set.
+      """
+
+    When I try `wp transient get foo2`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo2" is not set.
+      """
+
+    When I try `wp transient get foo3 --network`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo3" is not set.
+      """
+
+    When I run `wp transient set foo bar 60`
+    Then STDOUT should be:
+      """
+      Success: Transient added.
+      """
+
+    # Change timeout to be in the past.
+    When I run `wp option update _transient_timeout_foo 1321009871`
+    And I run `wp transient delete --expired`
+    Then STDOUT should contain:
+      """
+      transient deleted from the database.
+      """
+
+    When I try `wp transient get foo`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo" is not set.
+      """
+
+    When I run `wp transient set foo bar 60 --network`
+    Then STDOUT should be:
+      """
+      Success: Transient added.
+      """
+
+    # Change timeout to be in the past.
+    When I run `wp site option update _site_transient_timeout_foo 1321009871`
+    And I run `wp transient delete --expired`
+    Then STDOUT should contain:
+      """
+      transient deleted from the database.
+      """
+
+    When I try `wp transient get foo --network`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo" is not set.
       """

--- a/features/transient.feature
+++ b/features/transient.feature
@@ -55,12 +55,13 @@ Feature: Manage WordPress transient cache
       Success: Transient deleted.
       """
 
-    When I run `wp transient set foo bar --network`
+    When I run `wp transient delete --all`
+    And I run `wp transient set foo bar --network`
     And I run `wp transient set foo2 bar2 --network`
     And I run `wp transient delete --all`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
-      transients deleted from the database.
+      Success: 2 transients deleted from the database.
       """
 
   Scenario: Transient delete and other flags
@@ -72,13 +73,14 @@ Feature: Manage WordPress transient cache
       Error: Please specify transient key, or use --all or --expired.
       """
 
-    When I run `wp transient set foo bar`
+    When I run `wp transient delete --all`
+    And I run `wp transient set foo bar`
     And I run `wp transient set foo2 bar2`
     And I run `wp transient set foo3 bar3 --network`
     And I run `wp transient delete --all`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
-      transients deleted from the database.
+      Success: 3 transients deleted from the database.
       """
 
     When I try `wp transient get foo`
@@ -108,9 +110,9 @@ Feature: Manage WordPress transient cache
     # Change timeout to be in the past.
     When I run `wp option update _transient_timeout_foo 1321009871`
     And I run `wp transient delete --expired`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
-      transient deleted from the database.
+      Success: 1 expired transient deleted from the database.
       """
 
     When I try `wp transient get foo`
@@ -128,9 +130,9 @@ Feature: Manage WordPress transient cache
     # Change timeout to be in the past.
     When I run `wp option update _site_transient_timeout_foo 1321009871`
     And I run `wp transient delete --expired`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
-      transient deleted from the database.
+      Success: 1 expired transient deleted from the database.
       """
 
     When I try `wp transient get foo --network`
@@ -142,13 +144,14 @@ Feature: Manage WordPress transient cache
   Scenario: Network transient delete and other flags
     Given a WP multisite install
 
-    When I run `wp transient set foo bar`
+    When I run `wp transient delete --all`
+    And I run `wp transient set foo bar`
     And I run `wp transient set foo2 bar2`
     And I run `wp transient set foo3 bar3 --network`
     And I run `wp transient delete --all`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
-      transients deleted from the database.
+      Success: 3 transients deleted from the database.
       """
 
     When I try `wp transient get foo`
@@ -178,9 +181,9 @@ Feature: Manage WordPress transient cache
     # Change timeout to be in the past.
     When I run `wp option update _transient_timeout_foo 1321009871`
     And I run `wp transient delete --expired`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
-      transient deleted from the database.
+      Success: 1 expired transient deleted from the database.
       """
 
     When I try `wp transient get foo`
@@ -198,9 +201,9 @@ Feature: Manage WordPress transient cache
     # Change timeout to be in the past.
     When I run `wp site option update _site_transient_timeout_foo 1321009871`
     And I run `wp transient delete --expired`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
-      transient deleted from the database.
+      Success: 1 expired transient deleted from the database.
       """
 
     When I try `wp transient get foo --network`

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -225,7 +225,7 @@ class Transient_Command extends WP_CLI_Command {
 	/**
 	 * Deletes all expired transients.
 	 *
-	 * Always deletes the transients from the database too.
+	 * Only deletes the expired transients from the database.
 	 */
 	private function delete_expired() {
 		global $wpdb;
@@ -297,7 +297,7 @@ class Transient_Command extends WP_CLI_Command {
 	/**
 	 * Deletes all transients.
 	 *
-	 * Always deletes the transients from the database too.
+	 * Only deletes the transients from the database.
 	 */
 	private function delete_all() {
 		global $wpdb;

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -164,6 +164,9 @@ class Transient_Command extends WP_CLI_Command {
 	 *     # Delete all transients.
 	 *     $ wp transient delete --all
 	 *     Success: 14 transients deleted from the database.
+	 *
+	 *     # Delete all transients in a multsite.
+	 *     $ wp transient delete --all --network && wp site list --field=url | xargs -n1 -I % wp --url=% transient delete --all
 	 */
 	public function delete( $args, $assoc_args ) {
 		$key = ( ! empty( $args ) ) ? $args[0] : NULL;

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -228,46 +228,33 @@ class Transient_Command extends WP_CLI_Command {
 	private function delete_expired() {
 		global $wpdb;
 
+		$time = time();
+
 		$count = $wpdb->query(
-			$wpdb->prepare(
-				"DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
-					WHERE a.option_name LIKE %s
-					AND a.option_name NOT LIKE %s
-					AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
-					AND b.option_value < %d",
-				$wpdb->esc_like( '_transient_' ) . '%',
-				$wpdb->esc_like( '_transient_timeout_' ) . '%',
-				time()
-			)
+			"DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
+				WHERE a.option_name LIKE '\\_transient\\_%'
+				AND a.option_name NOT LIKE '\\_transient\\_timeout\\_%'
+				AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
+				AND b.option_value < {$time}"
 		);
 
 		if ( ! is_multisite() ) {
 			// Non-Multisite stores site transients in the options table.
 			$count += $wpdb->query(
-				$wpdb->prepare(
-					"DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
-						WHERE a.option_name LIKE %s
-						AND a.option_name NOT LIKE %s
-						AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
-						AND b.option_value < %d",
-					$wpdb->esc_like( '_site_transient_' ) . '%',
-					$wpdb->esc_like( '_site_transient_timeout_' ) . '%',
-					time()
-				)
+				"DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
+					WHERE a.option_name LIKE '\\_site\\_transient\\_%'
+					AND a.option_name NOT LIKE '\\_site\\_transient\\_timeout\\_%'
+					AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
+					AND b.option_value < {$time}"
 			);
 		} elseif ( is_multisite() && is_main_site() && is_main_network() ) {
 			// Multisite stores site transients in the sitemeta table.
 			$count += $wpdb->query(
-				$wpdb->prepare(
-					"DELETE a, b FROM {$wpdb->sitemeta} a, {$wpdb->sitemeta} b
-						WHERE a.meta_key LIKE %s
-						AND a.meta_key NOT LIKE %s
-						AND b.meta_key = CONCAT( '_site_transient_timeout_', SUBSTRING( a.meta_key, 17 ) )
-						AND b.meta_value < %d",
-					$wpdb->esc_like( '_site_transient_' ) . '%',
-					$wpdb->esc_like( '_site_transient_timeout_' ) . '%',
-					time()
-				)
+				"DELETE a, b FROM {$wpdb->sitemeta} a, {$wpdb->sitemeta} b
+					WHERE a.meta_key LIKE '\\_site\\_transient\\_%'
+					AND a.meta_key NOT LIKE '\\_site\\_transient\\_timeout\\_%'
+					AND b.meta_key = CONCAT( '_site_transient_timeout_', SUBSTRING( a.meta_key, 17 ) )
+					AND b.meta_value < {$time}"
 			);
 		}
 
@@ -296,25 +283,18 @@ class Transient_Command extends WP_CLI_Command {
 		global $wpdb;
 
 		$count = $wpdb->query(
-			$wpdb->prepare(
-				"DELETE FROM $wpdb->options WHERE option_name LIKE %s",
-				$wpdb->esc_like( '_transient_' ) . '%'
-			)
+			"DELETE FROM {$wpdb->options} WHERE option_name LIKE '\_transient\_%'"
 		);
 
 		if ( ! is_multisite() ) {
 			// Non-Multisite stores site transients in the options table.
 			$count += $wpdb->query(
-				$wpdb->prepare(
-					"DELETE FROM $wpdb->options WHERE option_name LIKE %s",
-					$wpdb->esc_like( '_site_transient_' ) . '%'
-				)
+				"DELETE FROM {$wpdb->options} WHERE option_name LIKE '\\_site\\_transient\\_%'"
 			);
 		} elseif ( is_multisite() && is_main_site() && is_main_network() ) {
 			// Multisite stores site transients in the sitemeta table.
-			$count += $wpdb->prepare(
-				"DELETE FROM $wpdb->sitemeta WHERE option_name LIKE %s",
-				$wpdb->esc_like( '_site_transient_' ) . '%'
+			$count += $wpdb->query(
+				"DELETE FROM {$wpdb->sitemeta} WHERE option_name LIKE '\\_site\\_transient\\_%'"
 			);
 		}
 

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -161,9 +161,17 @@ class Transient_Command extends WP_CLI_Command {
 	 *     $ wp transient delete --expired
 	 *     Success: 12 expired transients deleted from the database.
 	 *
+	 *     # Delete expired site transients.
+	 *     $ wp transient delete --expired --network
+	 *     Success: 1 expired transient deleted from the database.
+	 *
 	 *     # Delete all transients.
 	 *     $ wp transient delete --all
 	 *     Success: 14 transients deleted from the database.
+	 *
+	 *     # Delete all site transients.
+	 *     $ wp transient delete --all --network
+	 *     Success: 2 transients deleted from the database.
 	 *
 	 *     # Delete all transients in a multsite.
 	 *     $ wp transient delete --all --network && wp site list --field=url | xargs -n1 -I % wp --url=% transient delete --all

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -257,7 +257,7 @@ class Transient_Command extends WP_CLI_Command {
 					time()
 				)
 			);
-		} elseif ( is_multisite() && is_main_site() && is_main_network() ) {
+		} else {
 			// Multisite stores site transients in the sitemeta table.
 			$count += $wpdb->query(
 				$wpdb->prepare(
@@ -317,7 +317,7 @@ class Transient_Command extends WP_CLI_Command {
 					Utils\esc_like( '_site_transient_' ) . '%'
 				)
 			);
-		} elseif ( is_multisite() && is_main_site() && is_main_network() ) {
+		} else {
 			// Multisite stores site transients in the sitemeta table.
 			$count += $wpdb->prepare(
 				"DELETE FROM $wpdb->sitemeta WHERE option_name LIKE %s",

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -222,28 +222,67 @@ class Transient_Command extends WP_CLI_Command {
 
 	/**
 	 * Deletes all expired transients.
+	 *
+	 * Always deletes the transients from the database too.
 	 */
 	private function delete_expired() {
-		global $wpdb, $_wp_using_ext_object_cache;
+		global $wpdb;
 
-		// Always delete all transients from DB too.
-		$time = current_time('timestamp');
 		$count = $wpdb->query(
-			"DELETE a, b FROM $wpdb->options a, $wpdb->options b WHERE
-			a.option_name LIKE '\_transient\_%' AND
-			a.option_name NOT LIKE '\_transient\_timeout\_%' AND
-			b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
-			AND b.option_value < $time"
+			$wpdb->prepare(
+				"DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
+					WHERE a.option_name LIKE %s
+					AND a.option_name NOT LIKE %s
+					AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
+					AND b.option_value < %d",
+				$wpdb->esc_like( '_transient_' ) . '%',
+				$wpdb->esc_like( '_transient_timeout_' ) . '%',
+				time()
+			)
 		);
+
+		if ( ! is_multisite() ) {
+			// Non-Multisite stores site transients in the options table.
+			$count += $wpdb->query(
+				$wpdb->prepare(
+					"DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
+						WHERE a.option_name LIKE %s
+						AND a.option_name NOT LIKE %s
+						AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
+						AND b.option_value < %d",
+					$wpdb->esc_like( '_site_transient_' ) . '%',
+					$wpdb->esc_like( '_site_transient_timeout_' ) . '%',
+					time()
+				)
+			);
+		} elseif ( is_multisite() && is_main_site() && is_main_network() ) {
+			// Multisite stores site transients in the sitemeta table.
+			$count += $wpdb->query(
+				$wpdb->prepare(
+					"DELETE a, b FROM {$wpdb->sitemeta} a, {$wpdb->sitemeta} b
+						WHERE a.meta_key LIKE %s
+						AND a.meta_key NOT LIKE %s
+						AND b.meta_key = CONCAT( '_site_transient_timeout_', SUBSTRING( a.meta_key, 17 ) )
+						AND b.meta_value < %d",
+					$wpdb->esc_like( '_site_transient_' ) . '%',
+					$wpdb->esc_like( '_site_transient_timeout_' ) . '%',
+					time()
+				)
+			);
+		}
+
+		// The above queries delete the transient and the transient timeout
+		// thus each transient is counted as 2.
+		$count = $count / 2;
 
 		if ( $count > 0 ) {
 			WP_CLI::success( "$count expired transients deleted from the database." );
 		} else {
-			WP_CLI::success( "No expired transients found." );
+			WP_CLI::success( 'No expired transients found.' );
 		}
 
-		if ( $_wp_using_ext_object_cache ) {
-			WP_CLI::warning( 'Transients are stored in an external object cache, and this command only deletes those stored in the database. You must flush the cache to delete all transients.');
+		if ( wp_using_ext_object_cache() ) {
+			WP_CLI::warning( 'Transients are stored in an external object cache, and this command only deletes those stored in the database. You must flush the cache to delete all transients.' );
 		}
 	}
 

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -283,7 +283,7 @@ class Transient_Command extends WP_CLI_Command {
 		global $wpdb;
 
 		$count = $wpdb->query(
-			"DELETE FROM {$wpdb->options} WHERE option_name LIKE '\_transient\_%'"
+			"DELETE FROM {$wpdb->options} WHERE option_name LIKE '\\_transient\\_%'"
 		);
 
 		if ( ! is_multisite() ) {

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -319,9 +319,11 @@ class Transient_Command extends WP_CLI_Command {
 			);
 		} else {
 			// Multisite stores site transients in the sitemeta table.
-			$count += $wpdb->prepare(
-				"DELETE FROM $wpdb->sitemeta WHERE option_name LIKE %s",
-				Utils\esc_like( '_site_transient_' ) . '%'
+			$count += $wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM $wpdb->sitemeta WHERE meta_key LIKE %s",
+					Utils\esc_like( '_site_transient_' ) . '%'
+				)
 			);
 		}
 

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -1,5 +1,7 @@
 <?php
 
+use WP_CLI\Utils;
+
 /**
  * Adds, gets, and deletes entries in the WordPress Transient Cache.
  *
@@ -74,7 +76,7 @@ class Transient_Command extends WP_CLI_Command {
 	public function get( $args, $assoc_args ) {
 		list( $key ) = $args;
 
-		$func = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) ? 'get_site_transient' : 'get_transient';
+		$func  = Utils\get_flag_value( $assoc_args, 'network' ) ? 'get_site_transient' : 'get_transient';
 		$value = $func( $key );
 
 		if ( false === $value ) {
@@ -117,9 +119,9 @@ class Transient_Command extends WP_CLI_Command {
 	public function set( $args, $assoc_args ) {
 		list( $key, $value ) = $args;
 
-		$expiration = \WP_CLI\Utils\get_flag_value( $args, 2, 0 );
+		$expiration = Utils\get_flag_value( $args, 2, 0 );
 
-		$func = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) ? 'set_site_transient' : 'set_transient';
+		$func = Utils\get_flag_value( $assoc_args, 'network' ) ? 'set_site_transient' : 'set_transient';
 		if ( $func( $key, $value, $expiration ) ) {
 			WP_CLI::success( 'Transient added.' );
 		} else {
@@ -166,8 +168,8 @@ class Transient_Command extends WP_CLI_Command {
 	public function delete( $args, $assoc_args ) {
 		$key = ( ! empty( $args ) ) ? $args[0] : NULL;
 
-		$all = \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' );
-		$expired = \WP_CLI\Utils\get_flag_value( $assoc_args, 'expired' );
+		$all = Utils\get_flag_value( $assoc_args, 'all' );
+		$expired = Utils\get_flag_value( $assoc_args, 'expired' );
 
 		if ( true === $all ) {
 			$this->delete_all();
@@ -182,12 +184,12 @@ class Transient_Command extends WP_CLI_Command {
 			WP_CLI::error( 'Please specify transient key, or use --all or --expired.' );
 		}
 
-		$func = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) ? 'delete_site_transient' : 'delete_transient';
+		$func = Utils\get_flag_value( $assoc_args, 'network' ) ? 'delete_site_transient' : 'delete_transient';
 
 		if ( $func( $key ) ) {
 			WP_CLI::success( 'Transient deleted.' );
 		} else {
-			$func = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) ? 'get_site_transient' : 'get_transient';
+			$func = Utils\get_flag_value( $assoc_args, 'network' ) ? 'get_site_transient' : 'get_transient';
 			if ( $func( $key ) )
 				WP_CLI::error( 'Transient was not deleted even though the transient appears to exist.' );
 			else
@@ -235,8 +237,8 @@ class Transient_Command extends WP_CLI_Command {
 					AND a.option_name NOT LIKE %s
 					AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
 					AND b.option_value < %d",
-				\WP_CLI\Utils\esc_like( '_transient_' ) . '%',
-				\WP_CLI\Utils\esc_like( '_transient_timeout_' ) . '%',
+				Utils\esc_like( '_transient_' ) . '%',
+				Utils\esc_like( '_transient_timeout_' ) . '%',
 				time()
 			)
 		);
@@ -250,8 +252,8 @@ class Transient_Command extends WP_CLI_Command {
 						AND a.option_name NOT LIKE %s
 						AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
 						AND b.option_value < %d",
-					\WP_CLI\Utils\esc_like( '_site_transient_' ) . '%',
-					\WP_CLI\Utils\esc_like( '_site_transient_timeout_' ) . '%',
+					Utils\esc_like( '_site_transient_' ) . '%',
+					Utils\esc_like( '_site_transient_timeout_' ) . '%',
 					time()
 				)
 			);
@@ -264,8 +266,8 @@ class Transient_Command extends WP_CLI_Command {
 						AND a.meta_key NOT LIKE %s
 						AND b.meta_key = CONCAT( '_site_transient_timeout_', SUBSTRING( a.meta_key, 17 ) )
 						AND b.meta_value < %d",
-					\WP_CLI\Utils\esc_like( '_site_transient_' ) . '%',
-					\WP_CLI\Utils\esc_like( '_site_transient_timeout_' ) . '%',
+					Utils\esc_like( '_site_transient_' ) . '%',
+					Utils\esc_like( '_site_transient_timeout_' ) . '%',
 					time()
 				)
 			);
@@ -298,7 +300,7 @@ class Transient_Command extends WP_CLI_Command {
 		$count = $wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM $wpdb->options WHERE option_name LIKE %s",
-				\WP_CLI\Utils\esc_like( '_transient_' ) . '%'
+				Utils\esc_like( '_transient_' ) . '%'
 			)
 		);
 
@@ -307,14 +309,14 @@ class Transient_Command extends WP_CLI_Command {
 			$count += $wpdb->query(
 				$wpdb->prepare(
 					"DELETE FROM $wpdb->options WHERE option_name LIKE %s",
-					\WP_CLI\Utils\esc_like( '_site_transient_' ) . '%'
+					Utils\esc_like( '_site_transient_' ) . '%'
 				)
 			);
 		} elseif ( is_multisite() && is_main_site() && is_main_network() ) {
 			// Multisite stores site transients in the sitemeta table.
 			$count += $wpdb->prepare(
 				"DELETE FROM $wpdb->sitemeta WHERE option_name LIKE %s",
-				\WP_CLI\Utils\esc_like( '_site_transient_' ) . '%'
+				Utils\esc_like( '_site_transient_' ) . '%'
 			);
 		}
 

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -278,8 +278,13 @@ class Transient_Command extends WP_CLI_Command {
 		$count = $count / 2;
 
 		if ( $count > 0 ) {
-			$success_message = ( 1 === $count ) ? '%d expired transient deleted from the database.' : '%d expired transients deleted from the database.';
-			WP_CLI::success( sprintf( $success_message, $count ) );
+			WP_CLI::success(
+				sprintf(
+					'%d expired %s deleted from the database.',
+					$count,
+					Utils\pluralize( 'transient', $count )
+				)
+			);
 		} else {
 			WP_CLI::success( 'No expired transients found.' );
 		}
@@ -324,8 +329,13 @@ class Transient_Command extends WP_CLI_Command {
 		// thus some transients may be counted twice.
 
 		if ( $count > 0 ) {
-			$success_message = ( 1 === $count ) ? '%d transient deleted from the database.' : '%d transients deleted from the database.';
-			WP_CLI::success( sprintf( $success_message, $count ) );
+			WP_CLI::success(
+				sprintf(
+					'%d %s deleted from the database.',
+					$count,
+					Utils\pluralize( 'transient', $count )
+				)
+			);
 		} else {
 			WP_CLI::success( 'No transients found.' );
 		}

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -228,33 +228,46 @@ class Transient_Command extends WP_CLI_Command {
 	private function delete_expired() {
 		global $wpdb;
 
-		$time = time();
-
 		$count = $wpdb->query(
-			"DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
-				WHERE a.option_name LIKE '\\_transient\\_%'
-				AND a.option_name NOT LIKE '\\_transient\\_timeout\\_%'
-				AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
-				AND b.option_value < {$time}"
+			$wpdb->prepare(
+				"DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
+					WHERE a.option_name LIKE %s
+					AND a.option_name NOT LIKE %s
+					AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
+					AND b.option_value < %d",
+				\WP_CLI\Utils\esc_like( '_transient_' ) . '%',
+				\WP_CLI\Utils\esc_like( '_transient_timeout_' ) . '%',
+				time()
+			)
 		);
 
 		if ( ! is_multisite() ) {
 			// Non-Multisite stores site transients in the options table.
 			$count += $wpdb->query(
-				"DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
-					WHERE a.option_name LIKE '\\_site\\_transient\\_%'
-					AND a.option_name NOT LIKE '\\_site\\_transient\\_timeout\\_%'
-					AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
-					AND b.option_value < {$time}"
+				$wpdb->prepare(
+					"DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
+						WHERE a.option_name LIKE %s
+						AND a.option_name NOT LIKE %s
+						AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
+						AND b.option_value < %d",
+					\WP_CLI\Utils\esc_like( '_site_transient_' ) . '%',
+					\WP_CLI\Utils\esc_like( '_site_transient_timeout_' ) . '%',
+					time()
+				)
 			);
 		} elseif ( is_multisite() && is_main_site() && is_main_network() ) {
 			// Multisite stores site transients in the sitemeta table.
 			$count += $wpdb->query(
-				"DELETE a, b FROM {$wpdb->sitemeta} a, {$wpdb->sitemeta} b
-					WHERE a.meta_key LIKE '\\_site\\_transient\\_%'
-					AND a.meta_key NOT LIKE '\\_site\\_transient\\_timeout\\_%'
-					AND b.meta_key = CONCAT( '_site_transient_timeout_', SUBSTRING( a.meta_key, 17 ) )
-					AND b.meta_value < {$time}"
+				$wpdb->prepare(
+					"DELETE a, b FROM {$wpdb->sitemeta} a, {$wpdb->sitemeta} b
+						WHERE a.meta_key LIKE %s
+						AND a.meta_key NOT LIKE %s
+						AND b.meta_key = CONCAT( '_site_transient_timeout_', SUBSTRING( a.meta_key, 17 ) )
+						AND b.meta_value < %d",
+					\WP_CLI\Utils\esc_like( '_site_transient_' ) . '%',
+					\WP_CLI\Utils\esc_like( '_site_transient_timeout_' ) . '%',
+					time()
+				)
 			);
 		}
 
@@ -283,18 +296,25 @@ class Transient_Command extends WP_CLI_Command {
 		global $wpdb;
 
 		$count = $wpdb->query(
-			"DELETE FROM {$wpdb->options} WHERE option_name LIKE '\\_transient\\_%'"
+			$wpdb->prepare(
+				"DELETE FROM $wpdb->options WHERE option_name LIKE %s",
+				\WP_CLI\Utils\esc_like( '_transient_' ) . '%'
+			)
 		);
 
 		if ( ! is_multisite() ) {
 			// Non-Multisite stores site transients in the options table.
 			$count += $wpdb->query(
-				"DELETE FROM {$wpdb->options} WHERE option_name LIKE '\\_site\\_transient\\_%'"
+				$wpdb->prepare(
+					"DELETE FROM $wpdb->options WHERE option_name LIKE %s",
+					\WP_CLI\Utils\esc_like( '_site_transient_' ) . '%'
+				)
 			);
 		} elseif ( is_multisite() && is_main_site() && is_main_network() ) {
 			// Multisite stores site transients in the sitemeta table.
-			$count += $wpdb->query(
-				"DELETE FROM {$wpdb->sitemeta} WHERE option_name LIKE '\\_site\\_transient\\_%'"
+			$count += $wpdb->prepare(
+				"DELETE FROM $wpdb->sitemeta WHERE option_name LIKE %s",
+				\WP_CLI\Utils\esc_like( '_site_transient_' ) . '%'
 			);
 		}
 

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -276,7 +276,8 @@ class Transient_Command extends WP_CLI_Command {
 		$count = $count / 2;
 
 		if ( $count > 0 ) {
-			WP_CLI::success( "$count expired transients deleted from the database." );
+			$success_message = ( 1 === $count ) ? '%d expired transient deleted from the database.' : '%d expired transients deleted from the database.';
+			WP_CLI::success( sprintf( $success_message, $count ) );
 		} else {
 			WP_CLI::success( 'No expired transients found.' );
 		}
@@ -336,7 +337,8 @@ class Transient_Command extends WP_CLI_Command {
 		$count = $count / 2;
 
 		if ( $count > 0 ) {
-			WP_CLI::success( "$count transients deleted from the database." );
+			$success_message = ( 1 === $count ) ? '%d transient deleted from the database.' : '%d transients deleted from the database.';
+			WP_CLI::success( sprintf( $success_message, $count ) );
 		} else {
 			WP_CLI::success( 'No transients found.' );
 		}


### PR DESCRIPTION
* Delete also expired site transients.
* Add multisite support for site transients.
* Ensure correct counts due to transient timeouts being its own option.
* Add more tests for delete commands.

Fixes #30.
Fixes #41.