### PR TITLE
Rename `transient list` method to be consistent with other list commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,71 @@ network|site cache, please see docs for `wp transient`.
     $ wp transient type
     Transients are saved to the database.
 
+
+
+### wp transient list
+
+Lists transients and their values.
+
+~~~
+wp transient list [--search=<pattern>] [--exclude=<pattern>] [--network] [--unserialize] [--human-readable] [--fields=<fields>] [--format=<format>]
+~~~
+
+**OPTIONS**
+
+	[--search=<pattern>]
+		Use wildcards ( * and ? ) to match transient name.
+
+	[--exclude=<pattern>]
+		Pattern to exclude. Use wildcards ( * and ? ) to match transient name.
+
+	[--network]
+		Get the values of network|site transients. On single site, this is
+		a specially-named cache key. On multisite, this is a global cache
+		(instead of local to the site).
+
+	[--unserialize]
+		Unserialize transient values in output.
+
+	[--human-readable]
+		Human-readable output for expirations.
+
+	[--fields=<fields>]
+		Limit the output to specific object fields.
+
+	[--format=<format>]
+		The serialization format for the value.
+		---
+		default: table
+		options:
+		  - table
+		  - json
+		  - csv
+		  - count
+		  - yaml
+		---
+
+**AVAILABLE FIELDS**
+
+This field will be displayed by default for each matching option:
+
+* name
+* value
+* expiration
+
+**EXAMPLES**
+
+    # List all transients
+    $ wp transient list
+     +------+-------+---------------+
+     | name | value | expiration    |
+     +------+-------+---------------+
+     | foo  | bar   | 39 mins       |
+     | foo2 | bar2  | no expiration |
+     | foo3 | bar2  | expired       |
+     | foo4 | bar4  | 4 hours       |
+     +------+-------+---------------+
+
 ## Installing
 
 This package is included with WP-CLI itself, no additional installation necessary.

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
             "transient delete",
             "transient get",
             "transient set",
-            "transient type"
+            "transient type",
+            "transient list"
         ]
     },
     "autoload": {

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -292,7 +292,7 @@ class Transient_Command extends WP_CLI_Command {
 	 *
 	 * @subcommand list
 	 */
-	public function _list( $args, $assoc_args ) {
+	public function list_( $args, $assoc_args ) {
 		global $wpdb;
 
 		$network        = Utils\get_flag_value( $assoc_args, 'network', false );


### PR DESCRIPTION
See #48.

~For some reasons the package readme doesn't get updated when running `wp scaffold package-readme . --force`. Any ideas?~ The command was missing in composer.json.