### PR TITLE
Implement CS checking based on the `WP_CLI_CS` ruleset

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,8 @@
 .travis.yml
 behat.yml
 circle.yml
+phpcs.xml.dist
+phpunit.xml.dist
 bin/
 features/
 utils/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vendor/
 *.tar.gz
 composer.lock
 *.log
+phpunit.xml
+phpcs.xml
+.phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "wp-cli/entity-command": "^1.3 || ^2",
-        "wp-cli/wp-cli-tests": "^2.0.11"
+        "wp-cli/wp-cli-tests": "^2.1"
     },
     "config": {
         "process-timeout": 7200,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<ruleset name="WP-CLI-cache">
+	<description>Custom ruleset for WP-CLI cache-command</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
+
+	<!-- What to scan. -->
+	<file>.</file>
+
+	<!-- Show progress. -->
+	<arg value="p"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WP_CLI_CS"/>
+
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+	<!-- Make this sniff slightly less finicky. The WP Core default is 40. -->
+	<rule ref="Generic.Formatting.MultipleStatementAlignment">
+		<properties>
+			<property name="maxPadding" value="20"/>
+		</properties>
+	</rule>
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI\Cache"/><!-- Namespaces. -->
+				<element value="wpcli_cache"/><!-- Global variables and such. -->
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<exclude-pattern>*/src/(Cache|Transient)_Command\.php$</exclude-pattern>
+	</rule>
+
+</ruleset>

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -129,7 +129,7 @@ class Cache_Command extends WP_CLI_Command {
 	 */
 	public function delete( $args, $assoc_args ) {
 		list( $key, $group ) = $args;
-		$result = wp_cache_delete( $key, $group );
+		$result              = wp_cache_delete( $key, $group );
 
 		if ( false === $result ) {
 			WP_CLI::error( 'The object was not deleted.' );
@@ -188,7 +188,7 @@ class Cache_Command extends WP_CLI_Command {
 	 */
 	public function get( $args, $assoc_args ) {
 		list( $key, $group ) = $args;
-		$value = wp_cache_get( $key, $group );
+		$value               = wp_cache_get( $key, $group );
 
 		if ( false === $value ) {
 			WP_CLI::error( "Object with key '$key' and group '$group' not found." );

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -381,6 +381,7 @@ class Transient_Command extends WP_CLI_Command {
 			$query = "SELECT `option_name` as `name`, `option_value` as `value` FROM {$wpdb->options} {$where}";
 		}
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Prepared properly above.
 		$results = $wpdb->get_results( $query );
 
 		foreach ( $results as $result ) {

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -177,7 +177,7 @@ class Transient_Command extends WP_CLI_Command {
 	 *     $ wp transient delete --all --network && wp site list --field=url | xargs -n1 -I % wp --url=% transient delete --all
 	 */
 	public function delete( $args, $assoc_args ) {
-		$key = ( ! empty( $args ) ) ? $args[0] : NULL;
+		$key = ( ! empty( $args ) ) ? $args[0] : null;
 
 		$all     = Utils\get_flag_value( $assoc_args, 'all' );
 		$expired = Utils\get_flag_value( $assoc_args, 'expired' );
@@ -201,10 +201,11 @@ class Transient_Command extends WP_CLI_Command {
 			WP_CLI::success( 'Transient deleted.' );
 		} else {
 			$func = Utils\get_flag_value( $assoc_args, 'network' ) ? 'get_site_transient' : 'get_transient';
-			if ( $func( $key ) )
+			if ( $func( $key ) ) {
 				WP_CLI::error( 'Transient was not deleted even though the transient appears to exist.' );
-			else
+			} else {
 				WP_CLI::warning( 'Transient was not deleted; however, the transient does not appear to exist.' );
+			}
 		}
 	}
 


### PR DESCRIPTION
This basically adds a PHPCS ruleset using the new `WPCliCS`standard, fixes a few minor infractions and whitelists some others.

Please see the individual commits for more detail.

The build for this PR won't be able to pass until `wp-cli-tests` `2.1` has been released, upon which time, the build can just be restarted and should be green ;-)

[Edit]: this PR presumes that the https://github.com/wp-cli/cache-command/tree/prefix-global-variables branch will be pulled & merged before that time. /cc @schlessera 

Fixes #55

Related https://github.com/wp-cli/wp-cli/issues/5179