### PR TITLE
Bump Travis CI OS from `trusty` to `xenial`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ php: 7.4
 services:
   - mysql
 
-services:
-  - mysql
-
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ jobs:
     - stage: test
       php: 5.6
       env: WP_VERSION=3.7.11
+      dist: trusty
     - stage: test
       php: 5.6
       env: WP_VERSION=trunk

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 os: linux
-dist: trusty
+dist: xenial
 
 language: php
 php: 7.4
+
+services:
+  - mysql
+
+services:
+  - mysql
 
 notifications:
   email:


### PR DESCRIPTION
This PR changes the Travis CI configuration to use the `xenial` Ubuntu distribution instead of the `trusty` one by default.