### PR TITLE
Make transients deletion test more robust

### DIFF
--- a/features/transient.feature
+++ b/features/transient.feature
@@ -57,6 +57,10 @@ Feature: Manage WordPress transient cache
 
   Scenario: Deleting all transients on single site
     Given a WP install
+    And I run `wp transient list --format=count`
+    And save STDOUT as {EXISTING_TRANSIENTS}
+    And I run `expr {EXISTING_TRANSIENTS} + 2`
+    And save STDOUT as {EXPECTED_TRANSIENTS}
 
     When I try `wp transient delete`
     Then STDERR should be:
@@ -71,7 +75,7 @@ Feature: Manage WordPress transient cache
     And I run `wp transient delete --all`
     Then STDOUT should be:
       """
-      Success: 2 transients deleted from the database.
+      Success: {EXPECTED_TRANSIENTS} transients deleted from the database.
       """
 
     When I try `wp transient get foo`

--- a/features/transient.feature
+++ b/features/transient.feature
@@ -194,6 +194,10 @@ Feature: Manage WordPress transient cache
   Scenario: Deleting all transients on multisite
     Given a WP multisite install
     And I run `wp site create --slug=foo`
+    And I run `wp transient list --format=count`
+    And save STDOUT as {EXISTING_TRANSIENTS}
+    And I run `expr {EXISTING_TRANSIENTS} + 2`
+    And save STDOUT as {EXPECTED_TRANSIENTS}
 
     When I try `wp transient delete`
     Then STDERR should be:
@@ -210,7 +214,7 @@ Feature: Manage WordPress transient cache
     And I run `wp transient delete --all`
     Then STDOUT should be:
       """
-      Success: 2 transients deleted from the database.
+      Success: {EXPECTED_TRANSIENTS} transients deleted from the database.
       """
 
     When I try `wp transient get foo`
@@ -393,7 +397,7 @@ Feature: Manage WordPress transient cache
     And I run `wp option update _site_transient_timeout_foo6 1321009871`
 
     When I run `wp transient list --format=csv`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       name,value,expiration
       foo,bar,false
@@ -438,7 +442,7 @@ Feature: Manage WordPress transient cache
     And I run `wp site option update _site_transient_timeout_foo6 1321009871`
 
     When I run `wp transient list --format=csv`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       name,value,expiration
       foo,bar,false


### PR DESCRIPTION
Starting with 6.1, WordPress Core adds a `wp_global_styles_*` transient right after installation.

This has broken the transient deletion test where it tried to deduce the number of transients deleted by `transient delete --all`.

This PR makes this test more flexible so that it can calculate the number of expected deletions.