### PR TITLE
Warn when `wp transient list` is used with external object cache

### DIFF
--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -296,6 +296,10 @@ class Transient_Command extends WP_CLI_Command {
 	public function list_( $args, $assoc_args ) {
 		global $wpdb;
 
+		if ( wp_using_ext_object_cache() ) {
+			WP_CLI::warning( 'Transients are stored in an external object cache, and this command only shows those stored in the database.' );
+		}
+
 		$network        = Utils\get_flag_value( $assoc_args, 'network', false );
 		$unserialize    = Utils\get_flag_value( $assoc_args, 'unserialize', false );
 		$human_readable = Utils\get_flag_value( $assoc_args, 'human-readable', false );


### PR DESCRIPTION
Fixes https://github.com/wp-cli/cache-command/issues/61

```
$ wp transient list
+---------------------------------+------------------------------------------+------------+
| name                            | value                                    | expiration |
+---------------------------------+------------------------------------------+------------+
| doing_cron                      | 1677266261.8137209415435791015625        | false      |
| health-check-site-status-result | {"good":16,"recommended":4,"critical":1} | false      |
+---------------------------------+------------------------------------------+------------+
$ wp plugin install --activate wp-redis
Installing WP Redis (1.3.2)
Downloading installation package from https://downloads.wordpress.org/plugin/wp-redis.1.3.2.zip...
The authenticity of wp-redis.1.3.2.zip could not be verified as no signature was found.
Unpacking the package...
Installing the plugin...
Plugin installed successfully.
Activating 'wp-redis'...
Plugin 'wp-redis' activated.
Success: Installed 1 of 1 plugins.
$ wp redis enable
Success: Enabled WP Redis by creating wp-content/object-cache.php symlink.
$ wp transient list
Warning: Transients are stored in an external object cache, and this command only shows those stored in the database.
+---------------------------------+------------------------------------------+------------+
| name                            | value                                    | expiration |
+---------------------------------+------------------------------------------+------------+
| health-check-site-status-result | {"good":16,"recommended":4,"critical":1} | false      |
+---------------------------------+------------------------------------------+------------+
```