### PR TITLE
Add `wp cache flush-group` for flushing a cache group

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,27 @@ Errors if the object cache can't be flushed.
 
 
 
+### wp cache flush-group
+
+Removes all cache items in a group, if the object cache implementation supports it.
+
+~~~
+wp cache flush-group <group>
+~~~
+
+**OPTIONS**
+
+	<group>
+		Cache group key.
+
+**EXAMPLES**
+
+    # Clear cache group.
+    $ wp cache flush-group my_group
+    Success: Cache group 'my_group' was flushed.
+
+
+
 ### wp cache get
 
 Gets a value from the object cache.

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
             "cache decr",
             "cache delete",
             "cache flush",
+            "cache flush-group",
             "cache get",
             "cache incr",
             "cache replace",

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -133,6 +133,9 @@ Feature: Managed the WordPress object cache
       Error: Could not replace object 'bar' in group 'foo'. Does it not exist?
       """
 
+  @require-wp-6.1
+  Scenario: Some cache groups cannot be cleared.
+    Given a WP install
     When I run `wp cache flush-group add_multiple`
     Then STDOUT should be:
       """

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -133,12 +133,13 @@ Feature: Managed the WordPress object cache
       Error: Could not replace object 'bar' in group 'foo'. Does it not exist?
       """
 
-    When I run `wp cache clear-group add_multiple`
+    When I run `wp cache flush-group add_multiple`
     Then STDOUT should be:
       """
       Success: Cache group 'add_multiple' was flushed.
       """
 
+  @require-wp-6.1
   Scenario: Some cache groups cannot be cleared.
     Given a WP install
     And a wp-content/mu-plugins/unclearable-test-cache.php file:
@@ -154,7 +155,29 @@ Feature: Managed the WordPress object cache
       }
       $GLOBALS['wp_object_cache'] = new Dummy_Object_Cache();
       """
-    When I try `wp cache clear-group permanent_root_cache`
+    When I try `wp cache flush-group permanent_root_cache`
+    Then STDERR should be:
+      """
+      Error: Cache group 'permanent_root_cache' was not flushed.
+      """
+
+  @less-than-wp-6.1
+  Scenario: Some cache groups cannot be cleared.
+    Given a WP install
+    And a wp-content/mu-plugins/unclearable-test-cache.php file:
+      """php
+      <?php
+      class Dummy_Object_Cache extends WP_Object_Cache {
+        public function flush_group( $group ) {
+          if ( $group === 'permanent_root_cache' ) {
+            return false;
+          }
+          return parent::flush_group( $group );
+        }
+      }
+      $GLOBALS['wp_object_cache'] = new Dummy_Object_Cache();
+      """
+    When I try `wp cache flush-group permanent_root_cache`
     Then STDERR should be:
       """
       Error: Cache group 'permanent_root_cache' was not flushed.

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -144,6 +144,7 @@ Feature: Managed the WordPress object cache
       """
       Error: Cache group 'non_existing' is not supported.
       """
+
     When I try `wp cache clear-group false_return`
     Then STDERR should be:
       """

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -132,3 +132,20 @@ Feature: Managed the WordPress object cache
       """
       Error: Could not replace object 'bar' in group 'foo'. Does it not exist?
       """
+
+    When I run `wp cache clear-group add_multiple`
+    Then STDOUT should be:
+      """
+      Success: Cache group 'add_multiple' was flushed.
+      """
+
+    When I try `wp cache clear-group non_existing`
+    Then STDERR should be:
+      """
+      Error: Cache group 'non_existing' is not supported.
+      """
+    When I try `wp cache clear-group false_return`
+    Then STDERR should be:
+      """
+      Warning: Cache group 'false_return' was not be flushed.
+      """

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -139,16 +139,25 @@ Feature: Managed the WordPress object cache
       Success: Cache group 'add_multiple' was flushed.
       """
 
-    When I try `wp cache clear-group non_existing`
+  Scenario: Some cache groups cannot be cleared.
+    Given a WP install
+    And a wp-content/mu-plugins/unclearable-test-cache.php file:
+      """php
+      <?php
+      class Dummy_Object_Cache extends WP_Object_Cache {
+        public function flush_group( $group ) {
+          if ( $group === 'permanent_root_cache' ) {
+            return false;
+          }
+          return parent::flush_group( $group );
+        }
+      }
+      $GLOBALS['wp_object_cache'] = new Dummy_Object_Cache();
+      """
+    When I try `wp cache clear-group permanent_root_cache`
     Then STDERR should be:
       """
-      Error: Cache group 'non_existing' is not supported.
-      """
-
-    When I try `wp cache clear-group false_return`
-    Then STDERR should be:
-      """
-      Warning: Cache group 'false_return' was not be flushed.
+      Error: Cache group 'permanent_root_cache' was not flushed.
       """
 
   Scenario: Flushing cache on a multisite installation

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -180,7 +180,7 @@ Feature: Managed the WordPress object cache
     When I try `wp cache flush-group permanent_root_cache`
     Then STDERR should be:
       """
-      Error: Cache group 'permanent_root_cache' was not flushed.
+      Error: Group flushing is not supported.
       """
 
   Scenario: Flushing cache on a multisite installation

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -339,4 +339,32 @@ class Cache_Command extends WP_CLI_Command {
 		WP_CLI::line( $message );
 	}
 
+	/**
+	 * Removes all cache items in a group, if the object cache implementation supports it.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <group>
+	 * : Cache group key.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Clear cache group.
+	 *     $ wp cache clear-group my_group
+	 *
+	 * @subcommand clear-group
+	 */
+	public function clear_group( $args, $assoc_args ) {
+		list( $group ) = $args;
+
+		if (! wp_cache_supports( 'flush_group' )) {
+			WP_CLI::error( "Group flushing is not supported." );
+		}
+
+		if ( ! wp_cache_flush_group( $group ) ) {
+			WP_CLI::warning("Cache group '$group' was not be flushed." );
+		}
+		WP_CLI::success( "Cache group '$group' was flushed." );
+	}
+
 }

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -389,12 +389,12 @@ class Cache_Command extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Clear cache group.
-	 *     $ wp cache clear-group my_group
+	 *     $ wp cache flush-group my_group
 	 *     Success: Cache group 'my_group' was flushed.
 	 *
-	 * @subcommand clear-group
+	 * @subcommand flush-group
 	 */
-	public function clear_group( $args, $assoc_args ) {
+	public function flush_group( $args, $assoc_args ) {
 		list( $group ) = $args;
 
 		if ( ! function_exists( 'wp_cache_supports' ) || ! wp_cache_supports( 'flush_group' ) ) {

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -357,12 +357,16 @@ class Cache_Command extends WP_CLI_Command {
 	public function clear_group( $args, $assoc_args ) {
 		list( $group ) = $args;
 
-		if (! wp_cache_supports( 'flush_group' )) {
-			WP_CLI::error( "Group flushing is not supported." );
+		if ( ! function_exists( 'wp_cache_supports' ) ) {
+			WP_CLI::error( 'Checking cache features is only available in WordPress 6.1 and higher' );
+		}
+
+		if ( ! wp_cache_supports( 'flush_group' ) ) {
+			WP_CLI::error( 'Group flushing is not supported.' );
 		}
 
 		if ( ! wp_cache_flush_group( $group ) ) {
-			WP_CLI::warning("Cache group '$group' was not be flushed." );
+			WP_CLI::warning( "Cache group '$group' was not be flushed." );
 		}
 		WP_CLI::success( "Cache group '$group' was flushed." );
 	}

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -351,22 +351,19 @@ class Cache_Command extends WP_CLI_Command {
 	 *
 	 *     # Clear cache group.
 	 *     $ wp cache clear-group my_group
+	 *     Success: Cache group 'my_group' was flushed.
 	 *
 	 * @subcommand clear-group
 	 */
 	public function clear_group( $args, $assoc_args ) {
 		list( $group ) = $args;
 
-		if ( ! function_exists( 'wp_cache_supports' ) ) {
-			WP_CLI::error( 'Checking cache features is only available in WordPress 6.1 and higher' );
-		}
-
-		if ( ! wp_cache_supports( 'flush_group' ) ) {
+		if ( ! function_exists( 'wp_cache_supports' ) || ! wp_cache_supports( 'flush_group' ) ) {
 			WP_CLI::error( 'Group flushing is not supported.' );
 		}
 
 		if ( ! wp_cache_flush_group( $group ) ) {
-			WP_CLI::warning( "Cache group '$group' was not be flushed." );
+			WP_CLI::error( "Cache group '$group' was not flushed." );
 		}
 		WP_CLI::success( "Cache group '$group' was flushed." );
 	}


### PR DESCRIPTION
Needs extra input for testing.

I don't know how to create/fake a cache implementation for better behat testing.

Fixes https://github.com/wp-cli/cache-command/issues/80