### PR TITLE
Give a warning when flushing cache on multisite with `--url=<url>`

### DIFF
--- a/features/cache.feature
+++ b/features/cache.feature
@@ -138,11 +138,11 @@ Feature: Managed the WordPress object cache
     When I try `wp cache flush`
     Then STDERR should not contain:
       """
-      Warning: You are using a multisite installation. Flushing the cache will flush the cache for all sites.
+      Warning: Ignoring the --url=<url> argument, because flushing the cache affects all sites on a multisite installation.
       """
 
     When I try `wp cache flush --url=example.com`
     Then STDERR should contain:
       """
-      Warning: You are using a multisite installation. Flushing the cache will flush the cache for all sites.
+      Warning: Ignoring the --url=<url> argument, because flushing the cache affects all sites on a multisite installation.
       """

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -132,17 +132,18 @@ Feature: Managed the WordPress object cache
       """
       Error: Could not replace object 'bar' in group 'foo'. Does it not exist?
       """
+
   Scenario: Flushing cache on a multisite installation
     Given a WP multisite installation
 
     When I try `wp cache flush`
     Then STDERR should not contain:
       """
-      Warning: Ignoring the --url=<url> argument, because flushing the cache affects all sites on a multisite installation.
+      Warning: Ignoring the --url=<url> argument because flushing the cache affects all sites on a multisite installation.
       """
 
     When I try `wp cache flush --url=example.com`
     Then STDERR should contain:
       """
-      Warning: Ignoring the --url=<url> argument, because flushing the cache affects all sites on a multisite installation.
+      Warning: Ignoring the --url=<url> argument because flushing the cache affects all sites on a multisite installation.
       """

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -132,3 +132,17 @@ Feature: Managed the WordPress object cache
       """
       Error: Could not replace object 'bar' in group 'foo'. Does it not exist?
       """
+  Scenario: Flushing cache on a multisite installation
+    Given a WP multisite installation
+
+    When I try `wp cache flush`
+    Then STDERR should not contain:
+      """
+      Warning: You are using a multisite installation. Flushing the cache will flush the cache for all sites.
+      """
+
+    When I try `wp cache flush --url=example.com`
+    Then STDERR should contain:
+      """
+      Warning: You are using a multisite installation. Flushing the cache will flush the cache for all sites.
+      """

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -157,7 +157,7 @@ class Cache_Command extends WP_CLI_Command {
 	public function flush( $args, $assoc_args ) {
 
 		if ( WP_CLI::has_config( 'url' ) && ! empty( WP_CLI::get_config()['url'] ) && is_multisite() ) {
-			WP_CLI::warning( 'You are using a multisite installation. Flushing the cache will flush the cache for all sites.' );
+			WP_CLI::warning( 'Ignoring the --url=<url> argument, because flushing the cache affects all sites on a multisite installation.' );
 		}
 
 		$value = wp_cache_flush();

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -155,8 +155,12 @@ class Cache_Command extends WP_CLI_Command {
 	 *     Success: The cache was flushed.
 	 */
 	public function flush( $args, $assoc_args ) {
-		$value = wp_cache_flush();
 
+		if ( WP_CLI::has_config( 'url' ) && ! empty( WP_CLI::get_config()['url'] ) && is_multisite() ) {
+			WP_CLI::warning( 'You are using a multisite installation. Flushing the cache will flush the cache for all sites.' );
+		}
+
+		$value = wp_cache_flush();
 		if ( false === $value ) {
 			WP_CLI::error( 'The object cache could not be flushed.' );
 		}

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -157,7 +157,7 @@ class Cache_Command extends WP_CLI_Command {
 	public function flush( $args, $assoc_args ) {
 
 		if ( WP_CLI::has_config( 'url' ) && ! empty( WP_CLI::get_config()['url'] ) && is_multisite() ) {
-			WP_CLI::warning( 'Ignoring the --url=<url> argument, because flushing the cache affects all sites on a multisite installation.' );
+			WP_CLI::warning( 'Ignoring the --url=<url> argument because flushing the cache affects all sites on a multisite installation.' );
 		}
 
 		$value = wp_cache_flush();


### PR DESCRIPTION
Cache flushes on all sites, not just the current url.

Fixes https://github.com/wp-cli/cache-command/issues/78