### PR TITLE
Update warning text during multisite cache flushes

### DIFF
--- a/features/cache.feature
+++ b/features/cache.feature
@@ -192,13 +192,13 @@ Feature: Managed the WordPress object cache
     When I try `wp cache flush`
     Then STDERR should not contain:
       """
-      Warning: Ignoring the --url=<url> argument because flushing the cache affects all sites on a multisite installation.
+      Warning: Flushing the cache may affect all sites in a multisite installation, depending on the implementation of the object cache.
       """
 
     When I try `wp cache flush --url=example.com`
     Then STDERR should contain:
       """
-      Warning: Ignoring the --url=<url> argument because flushing the cache affects all sites on a multisite installation.
+      Warning: Flushing the cache may affect all sites in a multisite installation, depending on the implementation of the object cache.
       """
 
   @require-wp-6.1

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -157,7 +157,7 @@ class Cache_Command extends WP_CLI_Command {
 	public function flush( $args, $assoc_args ) {
 
 		if ( WP_CLI::has_config( 'url' ) && ! empty( WP_CLI::get_config()['url'] ) && is_multisite() ) {
-			WP_CLI::warning( 'Ignoring the --url=<url> argument because flushing the cache affects all sites on a multisite installation.' );
+			WP_CLI::warning( 'Flushing the cache may affect all sites in a multisite installation, depending on the implementation of the object cache.' );
 		}
 
 		$value = wp_cache_flush();


### PR DESCRIPTION
Update to the text from https://github.com/wp-cli/cache-command/pull/86, fixes https://github.com/wp-cli/cache-command/issues/78.

Context: Some object cache implementations won't flush the entire network, and the `--url=` param is still useful. Since WP CLI is still switching context to the site in question, we shouldn't use the "ignoring" verbiage as that isn't truly accurate.