### PR TITLE
Fix spelling for multisite in delete example

### DIFF
--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -173,7 +173,7 @@ class Transient_Command extends WP_CLI_Command {
 	 *     $ wp transient delete --all --network
 	 *     Success: 2 transients deleted from the database.
 	 *
-	 *     # Delete all transients in a multsite.
+	 *     # Delete all transients in a multisite.
 	 *     $ wp transient delete --all --network && wp site list --field=url | xargs -n1 -I % wp --url=% transient delete --all
 	 */
 	public function delete( $args, $assoc_args ) {


### PR DESCRIPTION
`/src/Transient_Command.php` L176

Current:

`Delete all transients in a multsite.`

This PR fixes the spelling.

`Delete all transients in a multisite.`