### PR TITLE
Update PHPDoc for `patch` commands

### DIFF
--- a/features/cache-patch.feature
+++ b/features/cache-patch.feature
@@ -8,6 +8,7 @@ Feature: Patch command available for the object cache
       $set_foo = function(){
         wp_cache_set( 'my_key', ['foo' => 'bar'] );
         wp_cache_set( 'other_key', ['fuz' => 'biz'] );
+        wp_cache_set( 'my_key_in_group', ['fuz' => 'biz'], 'my_group' );
 
         $complex_key = (object) [
             'foo' => (object) [
@@ -34,7 +35,19 @@ Feature: Patch command available for the object cache
       Success: Updated cache key 'complex_key'.
       """
 
+    When I try `wp cache patch insert my_key_in_group foo bar --group=my_group`
+    Then STDOUT should be:
+      """
+      Success: Updated cache key 'my_key_in_group'.
+      """
+
     When I try `wp cache patch insert unknown_key foo bar`
+    Then STDERR should be:
+      """
+      Error: Cannot create key "foo" on data type boolean
+      """
+
+    When I try `wp cache patch insert other_key foo bar --group=unknown_group`
     Then STDERR should be:
       """
       Error: Cannot create key "foo" on data type boolean
@@ -58,6 +71,12 @@ Feature: Patch command available for the object cache
       Success: Updated cache key 'complex_key'.
       """
 
+    When I try `wp cache patch update my_key_in_group fuz baz --group=my_group`
+    Then STDOUT should be:
+      """
+      Success: Updated cache key 'my_key_in_group'.
+      """
+
     When I try `wp cache patch update unknown_key foo test`
     Then STDERR should be:
       """
@@ -70,10 +89,22 @@ Feature: Patch command available for the object cache
       Error: No data exists for key "bar"
       """
 
+    When I try `wp cache patch update my_key foo baz --expiration=60`
+    Then STDOUT should be:
+      """
+      Success: Updated cache key 'my_key'.
+      """
+
     When I run `wp cache patch delete my_key foo`
     Then STDOUT should be:
       """
       Success: Updated cache key 'my_key'.
+      """
+
+    When I try `wp cache patch delete my_key_in_group fuz --group=my_group`
+    Then STDOUT should be:
+      """
+      Success: Updated cache key 'my_key_in_group'.
       """
 
     When I try `wp cache patch delete unknown_key foo`
@@ -86,4 +117,10 @@ Feature: Patch command available for the object cache
     Then STDERR should be:
       """
       Error: No data exists for key "bar"
+      """
+
+    When I try `wp cache patch delete my_key foo --group=my_group`
+    Then STDERR should be:
+      """
+      Error: No data exists for key "foo"
       """

--- a/features/cache-pluck.feature
+++ b/features/cache-pluck.feature
@@ -26,6 +26,18 @@ Feature: Pluck command available for the object cache
       baz
       """
 
+    When I run `wp cache pluck my_key_2 foo bar --format=json`
+    Then STDOUT should be:
+      """
+      "baz"
+      """
+
+    When I run `wp cache pluck my_key_2 foo --format=json`
+    Then STDOUT should be:
+      """
+      {"bar":"baz"}
+      """
+
     When I run `wp cache pluck my_key_3 foo --group=my_custom_group`
     Then STDOUT should be:
       """

--- a/features/transient-patch.feature
+++ b/features/transient-patch.feature
@@ -53,6 +53,18 @@ Feature: Patch command available for the transient cache
       {"foo":{"bar":"baz","fuz":"biz"}}
       """
 
+    When I run `wp transient patch insert my_key fiz bar --expiration=300`
+    Then STDOUT should be:
+      """
+      Success: Updated transient 'my_key'.
+      """
+
+    When I run `wp transient get my_key --format=json`
+    Then STDOUT should be:
+      """
+      {"foo":"bar","fuz":"baz","fiz":"bar"}
+      """
+
     When I try `wp transient patch insert unknown_key foo bar`
     Then STDERR should be:
       """

--- a/features/transient-pluck.feature
+++ b/features/transient-pluck.feature
@@ -17,6 +17,18 @@ Feature: Pluck command available for the transient cache
       baz
       """
 
+    When I run `wp transient pluck my_key_2 foo bar --format=json`
+    Then STDOUT should be:
+      """
+      "baz"
+      """
+
+    When I run `wp transient pluck my_key_2 foo --format=json`
+    Then STDOUT should be:
+      """
+      {"bar":"baz"}
+      """
+
     When I try `wp transient pluck unknown_key foo`
     Then STDERR should be:
       """

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -499,10 +499,10 @@ class Cache_Command extends WP_CLI_Command {
 	 * ---
 	 *
 	 * [--expiration=<expiration>]
-	 *  : Define how long to keep the value, in seconds. `0` means as long as possible.
-	 *  ---
-	 *  default: 0
-	 *  ---
+	 * : Define how long to keep the value, in seconds. `0` means as long as possible.
+	 * ---
+	 * default: 0
+	 * ---
 	 *
 	 * [--format=<format>]
 	 * : The serialization format for the value.

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -604,7 +604,7 @@ class Cache_Command extends WP_CLI_Command {
 		if ( $patched_value === $old_value ) {
 			WP_CLI::success( "Value passed for cache key '$key' is unchanged." );
 		} else {
-			$success = wp_cache_set( $key, $patched_value, $group, (int) $expiration );
+			$success = wp_cache_set( $key, $patched_value, $group, $expiration );
 			if ( $success ) {
 				WP_CLI::success( "Updated cache key '$key'." );
 			} else {

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -516,7 +516,7 @@ class Cache_Command extends WP_CLI_Command {
 	public function patch( $args, $assoc_args ) {
 		list( $action, $key ) = $args;
 		$group                = Utils\get_flag_value( $assoc_args, 'group' );
-		$expiration           = Utils\get_flag_value( $assoc_args, 'expiration' );
+		$expiration           = (int) Utils\get_flag_value( $assoc_args, 'expiration' );
 
 		$key_path = array_map(
 			function ( $key ) {

--- a/src/Transient_Command.php
+++ b/src/Transient_Command.php
@@ -497,6 +497,9 @@ class Transient_Command extends WP_CLI_Command {
 	 *
 	 * [--expiration=<expiration>]
 	 * : Time until expiration, in seconds.
+	 * ---
+	 * default: 0
+	 * ---
 	 *
 	 * [--network]
 	 * : Get the value of a network|site transient. On single site, this is
@@ -505,7 +508,7 @@ class Transient_Command extends WP_CLI_Command {
 	 */
 	public function patch( $args, $assoc_args ) {
 		list( $action, $key ) = $args;
-		$expiration           = (int) Utils\get_flag_value( $assoc_args, 'expiration', 0 );
+		$expiration           = (int) Utils\get_flag_value( $assoc_args, 'expiration' );
 
 		$read_func  = Utils\get_flag_value( $assoc_args, 'network' ) ? 'get_site_transient' : 'get_transient';
 		$write_func = Utils\get_flag_value( $assoc_args, 'network' ) ? 'set_site_transient' : 'set_transient';


### PR DESCRIPTION
- Remove extra spaces in `cache patch` PHPDoc annotation
- Specify default value for `expiration` argument in `transient patch` PHPDoc annotation